### PR TITLE
Fix missing semicolon for linters

### DIFF
--- a/tasks/css2js.js
+++ b/tasks/css2js.js
@@ -52,7 +52,7 @@
                     '        }\n' +
                     '    } else {\n' +
                     '        try {\n' +
-                    '            styleEl.innerHTML = cssText\n' +
+                    '            styleEl.innerHTML = cssText;\n' +
                     '        } catch(e) {\n' +
                     '            styleEl.innerText = cssText;\n' +
                     '        }\n' +


### PR DESCRIPTION
This PR is just to add a semicolon to the grunt task, css2js.js line: 55.

This task is great! Just need to have it pass our linter rules. Thank you.